### PR TITLE
romio/daos: add support for DUNS in the DAOS ADIO driver

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos.h
+++ b/src/mpi/romio/adio/ad_daos/ad_daos.h
@@ -11,6 +11,7 @@
 #include <gurt/list.h>
 #include <daos.h>
 #include <daos_fs.h>
+#include <daos_uns.h>
 
 /* #define D_PRINT_IO */
 /* #define D_PRINT_IO_MEM */
@@ -31,10 +32,8 @@ struct adio_daos_hdl {
 };
 
 struct ADIO_DAOS_cont {
-    /** container uuid */
-    uuid_t cuuid;
-    /** pool uuid */
-    uuid_t puuid;
+    /** pool, container uuids + other attributes */
+    struct duns_attr_t attr;
     /** Container name (Path to the file opened) */
     char *cont_name;
     /** Object name (File name) */
@@ -49,10 +48,6 @@ struct ADIO_DAOS_cont {
     dfs_obj_t *obj;
     /** Array Object ID for the MPI file */
     daos_obj_id_t oid;
-    /** Object class of the DAOS object associated with the file */
-    daos_oclass_id_t obj_class;
-    /** data size to store in a dkey */
-    daos_size_t chunk_size;
     /** file open mode */
     unsigned int amode;
     /** Event queue to store all async requests on file */

--- a/src/mpi/romio/adio/ad_daos/ad_daos_close.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_close.c
@@ -28,8 +28,10 @@ void ADIOI_DAOS_Close(ADIO_File fd, int *error_code)
     adio_daos_poh_release(cont->p);
     cont->p = NULL;
 
-    ADIOI_Free(cont->obj_name);
-    ADIOI_Free(cont->cont_name);
+    if (rank == 0) {
+        ADIOI_Free(cont->obj_name);
+        ADIOI_Free(cont->cont_name);
+    }
     ADIOI_Free(fd->fs_ptr);
     fd->fs_ptr = NULL;
 


### PR DESCRIPTION
- remove associated code for hashing file name to uuid and use the
  DUNS to determine the pool/container uuids
- fall back to env variables as non-default option

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
