### PR TITLE
romio/daos: conditionally compile on libdaos major version

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
@@ -146,11 +146,12 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
     phdl->type = DAOS_POOL;
     uuid_copy(phdl->uuid, uuid);
 
+    char *group = NULL;
+    daos_pool_info_t pool_info;
+#if DAOS_API_VERSION_MAJOR < 1
     /** Get the SVCL and Server group from env variables. This is temp as those
      * won't be needed later */
     char *svcl_str = NULL;
-    char *group = NULL;
-    daos_pool_info_t pool_info;
     d_rank_list_t *svcl = NULL;
 
     svcl_str = getenv("DAOS_SVCL");
@@ -162,10 +163,15 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
             goto free_hdl;
         }
     }
+#endif
     group = getenv("DAOS_GROUP");
 
+#if DAOS_API_VERSION_MAJOR < 1
     rc = daos_pool_connect(uuid, group, svcl, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
     d_rank_list_free(svcl);
+#else
+    rc = daos_pool_connect(uuid, group, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
+#endif
     if (rc < 0) {
         PRINT_MSG(stderr, "Failed to connect to pool (%d)\n", rc);
         goto free_hdl;


### PR DESCRIPTION
With this change the the DAOS ADIO driver conditionally compiles
to detect if it is being built against the original (before major
version 1) libdaos API, or the newer API. Major version 1 of
libdaos removes the need for daos clients to specify a pool service
replica rank list.

PR-repos: daos@PR-3935:3

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
