### PR TITLE
romio/daos: change packaging for building with libdaos.so.1

### DIFF
--- a/mpich-EL_7.spec
+++ b/mpich-EL_7.spec
@@ -1,10 +1,10 @@
 %global cart_major 4
-%global daos_major 0
+%global daos_major 1
 
 Summary:        A high-performance implementation of MPI
 Name:           mpich
 Version:        3.4~a2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 URL:            http://www.mpich.org/
 
@@ -41,7 +41,7 @@ BuildRequires:  python36-devel
 %endif
 BuildRequires:  automake >= 1.15
 BuildRequires:  libtool >= 2.4.4
-BuildRequires:  daos-devel
+BuildRequires:  daos-devel >= 1.1.2.2
 BuildRequires:  libuuid-devel
 Provides:       mpi
 Provides:       mpich2 = %{version}
@@ -98,7 +98,7 @@ Requires:       gcc-gfortran
 %if (0%{?fedora} >= 30)
 Requires:       rpm-mpi-hooks
 %endif
-Requires:       daos-devel
+Requires:       daos-devel >= 1.1.2.2
 Provides:       mpich2-devel = 3.0.1
 Obsoletes:      mpich2-devel < 3.0
 # the standard EL7 compatibility package
@@ -347,6 +347,9 @@ find %{buildroot} -type f -name "*.la" -delete
 %{python3_sitearch}/%{name}.pth
 
 %changelog
+* Tue Dec 08 2020 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-2
+- Update packaging for building with libdaos.so.1
+
 * Tue May 12 2020 Brian J. Murrell <brian.murrell@intel.com> - 3.4~a2-1
 - Update to 3.4a2
 - Disabled %check due to https://github.com/pmodels/mpich/issues/4534

--- a/mpich-LEAP_15.spec
+++ b/mpich-LEAP_15.spec
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%global daos_major 0
+%global daos_major 1
 
 # Static libraries are disabled by default
 # for non HPC builds
@@ -62,7 +62,7 @@
 
 Name:           %{package_name}%{?testsuite:-testsuite}
 Version:        %{vers}
-Release:        3
+Release:        4
 Summary:        High-performance and widely portable implementation of MPI
 License:        MIT
 Group:          Development/Libraries/Parallel
@@ -102,7 +102,7 @@ BuildRequires:  mpi-selector
 BuildRequires:  python-devel
 BuildRequires:  sysfsutils
 BuildRequires:  libfabric-devel
-BuildRequires:  daos-devel
+BuildRequires:  daos-devel >= 1.1.2.2
 Provides:       %{package_name}-daos-%{daos_major}
 
 Provides:       mpi
@@ -152,7 +152,7 @@ Requires:       libstdc++-devel
 %hpc_requires_devel
 %endif
 Requires:       %{name} = %{version}
-Requires:       daos-devel
+Requires:       daos-devel >= 1.1.2.2
 
 %description devel
 MPICH is a freely available, portable implementation of MPI, the
@@ -460,6 +460,9 @@ fi
 %endif # !testsuite
 
 %changelog
+* Tue Dec 08 2020 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-4
+- Update packaging for building with libdaos.so.1
+
 * Mon Jun 22 2020 Brian J. Murrell <brian.murrell@intel.com> - 3.4~a2-3
 - Add Requires: daos-devel to devel subpackage
 


### PR DESCRIPTION
Update daos_major definition in spec files to update the "virtual"
Provides (mpich-cart-4-daos-1 instead of mpich-cart-4-daos-0).

PR-repos: daos@PR-3935:10

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
