### PR TITLE
romio/daos: change packaging for building with libdaos.so.1

### DIFF
--- a/Makefile-rpm.mk
+++ b/Makefile-rpm.mk
@@ -1,7 +1,6 @@
 NAME    := mpich
 SRC_EXT := gz
 
-PR_REPOS      := #leave blank
 EL_7_PR_REPOS := automake libtool
 
 GIT_TAG := v3.3

--- a/mpich-EL_7.spec
+++ b/mpich-EL_7.spec
@@ -346,7 +346,7 @@ find %{buildroot} -type f -name "*.la" -delete
 %{python3_sitearch}/%{name}.pth
 
 %changelog
-* Tue Dec 08 2020 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-2
+* Wed Jan 20 2021 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-2
 - Update packaging for building with libdaos.so.1
 
 * Tue May 12 2020 Brian J. Murrell <brian.murrell@intel.com> - 3.4~a2-1

--- a/mpich-EL_7.spec
+++ b/mpich-EL_7.spec
@@ -1,10 +1,9 @@
-%global cart_major 4
-%global daos_major 0
+%global daos_major 1
 
 Summary:        A high-performance implementation of MPI
 Name:           mpich
 Version:        3.4~a2
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 URL:            http://www.mpich.org/
 
@@ -52,7 +51,7 @@ Obsoletes:      mpich-3.0 < 3.1
 Obsoletes:      mpich-3.2 < 3.3
 Requires:       environment(modules)
 Provides:       bundled(hwloc) = 2.0.1rc2
-Provides:       %{name}-cart-%{cart_major}-daos-%{daos_major}
+Provides:       %{name}-daos-%{daos_major}
 
 %description
 MPICH is a high-performance and widely portable implementation of the Message
@@ -84,7 +83,7 @@ Obsoletes:      mpich2-autoload < 3.0
 Obsoletes:      mpich-3.0-autoload < 3.1
 # and it's standard package
 Obsoletes:      mpich-3.2-autoload < 3.3
-Provides:       %{name}-autoload-cart-%{cart_major}-daos-%{daos_major}
+Provides:       %{name}-autoload-daos-%{daos_major}
 
 %description autoload
 This package contains profile files that make mpich automatically loaded.
@@ -125,14 +124,14 @@ Contains documentations, examples and man-pages for mpich
 
 %package -n python2-mpich
 Summary:        mpich support for Python 2
-Provides:       %{name}-python2-mpich-cart-%{cart_major}-daos-%{daos_major}
+Provides:       %{name}-python2-mpich-daos-%{daos_major}
 
 %description -n python2-mpich
 mpich support for Python 2.
 
 %package -n python3-mpich
 Summary:        mpich support for Python 3
-Provides:       %{name}-python3-mpich-cart-%{cart_major}-daos-%{daos_major}
+Provides:       %{name}-python3-mpich-daos-%{daos_major}
 
 %description -n python3-mpich
 mpich support for Python 3.
@@ -347,6 +346,9 @@ find %{buildroot} -type f -name "*.la" -delete
 %{python3_sitearch}/%{name}.pth
 
 %changelog
+* Tue Dec 08 2020 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-2
+- Update packaging for building with libdaos.so.1
+
 * Tue May 12 2020 Brian J. Murrell <brian.murrell@intel.com> - 3.4~a2-1
 - Update to 3.4a2
 - Disabled %check due to https://github.com/pmodels/mpich/issues/4534

--- a/mpich-LEAP_15.spec
+++ b/mpich-LEAP_15.spec
@@ -460,7 +460,7 @@ fi
 %endif # !testsuite
 
 %changelog
-* Tue Dec 08 2020 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-4
+* Wed Jan 20 2021 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-4
 - Update packaging for building with libdaos.so.1
 
 * Mon Jun 22 2020 Brian J. Murrell <brian.murrell@intel.com> - 3.4~a2-3

--- a/mpich-LEAP_15.spec
+++ b/mpich-LEAP_15.spec
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%global daos_major 0
+%global daos_major 1
 
 # Static libraries are disabled by default
 # for non HPC builds
@@ -62,7 +62,7 @@
 
 Name:           %{package_name}%{?testsuite:-testsuite}
 Version:        %{vers}
-Release:        3
+Release:        4
 Summary:        High-performance and widely portable implementation of MPI
 License:        MIT
 Group:          Development/Libraries/Parallel
@@ -460,6 +460,9 @@ fi
 %endif # !testsuite
 
 %changelog
+* Tue Dec 08 2020 Kenneth Cain <kenneth.c.cain@intel.com> - 3.4~a2-4
+- Update packaging for building with libdaos.so.1
+
 * Mon Jun 22 2020 Brian J. Murrell <brian.murrell@intel.com> - 3.4~a2-3
 - Add Requires: daos-devel to devel subpackage
 

--- a/packaging/rpm_chrootbuild
+++ b/packaging/rpm_chrootbuild
@@ -6,6 +6,13 @@ set -uex
 IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 
 if [ -w /etc/mock/"$CHROOT_NAME".cfg ]; then
+    # Remove the distro repos
+    if [[ $CHROOT_NAME =~ opensuse-leap-* ]]; then
+        ed /etc/mock/"$CHROOT_NAME".cfg << EOF
+/^# repos$/+2;/^"""$/-1d
+wq
+EOF
+    fi
     echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/"$CHROOT_NAME".cfg
     for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
         branch="master"

--- a/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
@@ -148,7 +148,7 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
 
     char *group = NULL;
     daos_pool_info_t pool_info;
-#if DAOS_API_VERSION_MAJOR < 1
+#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
     /** Get the SVCL and Server group from env variables. This is temp as those
      * won't be needed later */
     char *svcl_str = NULL;
@@ -166,7 +166,7 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
 #endif
     group = getenv("DAOS_GROUP");
 
-#if DAOS_API_VERSION_MAJOR < 1
+#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
     rc = daos_pool_connect(uuid, group, svcl, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
     d_rank_list_free(svcl);
 #else

--- a/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
@@ -148,7 +148,7 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
 
     char *group = NULL;
     daos_pool_info_t pool_info;
-#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
+#if !defined(DAOS_API_VERSION_MAJOR) || DAOS_API_VERSION_MAJOR < 1
     /** Get the SVCL and Server group from env variables. This is temp as those
      * won't be needed later */
     char *svcl_str = NULL;
@@ -166,7 +166,7 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
 #endif
     group = getenv("DAOS_GROUP");
 
-#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
+#if !defined(DAOS_API_VERSION_MAJOR) || DAOS_API_VERSION_MAJOR < 1
     rc = daos_pool_connect(uuid, group, svcl, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
     d_rank_list_free(svcl);
 #else


### PR DESCRIPTION
romio/daos: packaging, code to build libdaos API versions 0/1

Update daos_major definition in spec files to update the "virtual"
Provides (mpich-daos-1 instead of mpich-cart-4-daos-0).

Fix Makefile-rpm.mk (remove PR_REPOS blank assignment).

Enhance the conditional compilation logic in the daos adio
driver for compiling against libdaos.so.0 (old API) that does not
provide a DAOS_API_MAJOR_VERSION preprocessor macro.

PR-repos: daos@PR-3935:53

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
