### PR TITLE
romio/daos: better conditionals to build with libdaos.so.0/1

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_hhash.c
@@ -148,7 +148,7 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
 
     char *group = NULL;
     daos_pool_info_t pool_info;
-#if DAOS_API_VERSION_MAJOR < 1
+#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
     /** Get the SVCL and Server group from env variables. This is temp as those
      * won't be needed later */
     char *svcl_str = NULL;
@@ -166,7 +166,7 @@ int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl)
 #endif
     group = getenv("DAOS_GROUP");
 
-#if DAOS_API_VERSION_MAJOR < 1
+#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
     rc = daos_pool_connect(uuid, group, svcl, DAOS_PC_RW, &phdl->open_hdl, &pool_info, NULL);
     d_rank_list_free(svcl);
 #else


### PR DESCRIPTION
Enhance the conditional compilation logic in the daos adio
driver for compiling against libdaos.so.0 (old API) that does not
provide a DAOS_API_MAJOR_VERSION preprocessor macro.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] You or your company has a signed contributor's agreement on file with Argonne
* [ ] For non-Argonne authors, request an explicit comment from your companies PR approval manager
