### PR TITLE
romio/daos: add support for DAOS pool and container labels

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos.h
+++ b/src/mpi/romio/adio/ad_daos/ad_daos.h
@@ -25,6 +25,7 @@
 struct adio_daos_hdl {
     d_list_t entry;
     uuid_t uuid;
+    char *label;
     daos_handle_t open_hdl;
     dfs_t *dfs;
     int ref;
@@ -76,13 +77,14 @@ void ADIOI_DAOS_Init(int *error_code);
 /** Container/Pool Handle Hash functions */
 int adio_daos_hash_init(void);
 void adio_daos_hash_finalize(void);
-struct adio_daos_hdl *adio_daos_poh_lookup(const uuid_t uuid);
-int adio_daos_poh_insert(uuid_t uuid, daos_handle_t poh, struct adio_daos_hdl **hdl);
-int adio_daos_poh_lookup_connect(uuid_t uuid, struct adio_daos_hdl **hdl);
+struct adio_daos_hdl *adio_daos_poh_lookup(struct duns_attr_t *attr);
+int adio_daos_poh_insert(struct duns_attr_t *attr, daos_handle_t poh, struct adio_daos_hdl **hdl);
+int adio_daos_poh_lookup_connect(struct duns_attr_t *attr, struct adio_daos_hdl **hdl);
 void adio_daos_poh_release(struct adio_daos_hdl *hdl);
-struct adio_daos_hdl *adio_daos_coh_lookup(const uuid_t uuid);
-int adio_daos_coh_insert(uuid_t uuid, daos_handle_t coh, struct adio_daos_hdl **hdl);
-int adio_daos_coh_lookup_create(daos_handle_t poh, uuid_t uuid, int amode,
+struct adio_daos_hdl *adio_daos_coh_lookup(struct duns_attr_t *attr);
+int adio_daos_coh_insert(struct duns_attr_t *attr, daos_handle_t coh, dfs_t * dfs,
+                         struct adio_daos_hdl **hdl);
+int adio_daos_coh_lookup_create(daos_handle_t poh, struct duns_attr_t *attr, int amode,
                                 bool create, struct adio_daos_hdl **hdl);
 void adio_daos_coh_release(struct adio_daos_hdl *hdl);
 

--- a/src/mpi/romio/adio/ad_daos/ad_daos_close.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_close.c
@@ -31,11 +31,16 @@ void ADIOI_DAOS_Close(ADIO_File fd, int *error_code)
     if (rank == 0) {
         ADIOI_Free(cont->obj_name);
         ADIOI_Free(cont->cont_name);
-        if (cont->attr.da_rel_path) {
-            MPL_direct_free(cont->attr.da_rel_path);
-            cont->attr.da_rel_path = NULL;
-        }
     }
+#if DAOS_API_VERSION_MAJOR > 1 || DAOS_API_VERSION_MINOR > 2
+    duns_destroy_attr(&cont->attr);
+#else
+    if (cont->attr.da_rel_path) {
+        MPL_direct_free(cont->attr.da_rel_path);
+        cont->attr.da_rel_path = NULL;
+    }
+#endif
+
     ADIOI_Free(fd->fs_ptr);
     fd->fs_ptr = NULL;
 


### PR DESCRIPTION
DAOS now supports labels in addition to uuids for pools and container.
Update the DAOS ADIO driver to work with labels, depending on the API
version of DAOS being used.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
