### PR TITLE
romio/daos: fix build issue introduced by changing count to MPI_Aint

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos.h
+++ b/src/mpi/romio/adio/ad_daos/ad_daos.h
@@ -100,8 +100,7 @@ void adio_daos_coh_release(struct adio_daos_hdl *hdl);
 
 int ADIOI_DAOS_aio_free_fn(void *extra_state);
 int ADIOI_DAOS_aio_poll_fn(void *extra_state, MPI_Status * status);
-int ADIOI_DAOS_aio_wait_fn(MPI_Aint count, void **array_of_states, double timeout,
-                           MPI_Status * status);
+int ADIOI_DAOS_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status);
 int ADIOI_DAOS_err(const char *myname, const char *filename, int line, int rc);
 
 void ADIOI_DAOS_Open(ADIO_File fd, int *error_code);

--- a/src/mpi/romio/adio/ad_daos/ad_daos_io.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_io.c
@@ -187,8 +187,7 @@ int ADIOI_DAOS_aio_poll_fn(void *extra_state, MPI_Status * status)
 }
 
 /* wait for multiple requests to complete */
-int ADIOI_DAOS_aio_wait_fn(MPI_Aint count, void **array_of_states, double timeout,
-                           MPI_Status * status)
+int ADIOI_DAOS_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status)
 {
 
     struct ADIO_DAOS_req **aio_reqlist;

--- a/src/mpi/romio/adio/ad_daos/ad_daos_io_str.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_io_str.c
@@ -25,9 +25,6 @@ ADIOI_DAOS_StridedListIO(ADIO_File fd, const void *buf, MPI_Aint count,
                          MPI_Request * request, int rw_type, int *error_code);
 
 static MPIX_Grequest_class ADIOI_DAOS_greq_class = 0;
-int ADIOI_DAOS_aio_free_fn(void *extra_state);
-int ADIOI_DAOS_aio_poll_fn(void *extra_state, MPI_Status * status);
-int ADIOI_DAOS_aio_wait_fn(int count, void **array_of_states, double timeout, MPI_Status * status);
 
 void ADIOI_DAOS_ReadStrided(ADIO_File fd, void *buf, MPI_Aint count,
                             MPI_Datatype datatype, int file_ptr_type,


### PR DESCRIPTION
## Pull Request Description

Cherry pick of the official MPICH PR https://github.com/pmodels/mpich/pull/6247 from @mchaarawi 

- the wait_fn still expects the count to be of type int and not MPI_Aint, so revert the change that had made it MPI_Aint in the daos adio driver.
- remove redundant declarations of the aio functions.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
